### PR TITLE
[BigUint]: Reorganized Benchmarks

### DIFF
--- a/benches/bench_biguint.rs
+++ b/benches/bench_biguint.rs
@@ -11,61 +11,14 @@ extern crate num_bigint;
 extern crate test;
 
 #[cfg(test)]
-mod local_biguint_benchmarks {
-    use nordint::BigUint;
+mod biguint_benchmarks {
+    use nordint::BigUint as LocalBigUint;
+    use num_bigint::BigUint as CrateBigUint;
     use test::Bencher;
 
-    #[bench]
-    fn bench_fib_27_local(b: &mut Bencher) {
-        b.iter(|| {
-            BigUint::fib(27);
-        });
-    }
-
-    #[bench]
-    fn bench_fib_272_local(b: &mut Bencher) {
-        b.iter(|| {
-            BigUint::fib(272);
-        });
-    }
-
-    #[bench]
-    fn bench_fib_2727_local(b: &mut Bencher) {
-        b.iter(|| {
-            BigUint::fib(2_727);
-        });
-    }
-
-    #[bench]
-    fn bench_fac_27_local(b: &mut Bencher) {
-        b.iter(|| {
-            BigUint::fac(27);
-        });
-    }
-
-    #[bench]
-    fn bench_fac_272_local(b: &mut Bencher) {
-        b.iter(|| {
-            BigUint::fac(272);
-        });
-    }
-
-    #[bench]
-    fn bench_fac_2727_local(b: &mut Bencher) {
-        b.iter(|| {
-            BigUint::fac(2727);
-        });
-    }
-}
-
-#[cfg(test)]
-mod crate_biguint_benchmarks {
-    use num_bigint::BigUint;
-    use test::Bencher;
-
-    fn fib_generic(mut first: BigUint, mut second: BigUint, n: usize) -> BigUint {
+    fn fib_generic(mut first: CrateBigUint, mut second: CrateBigUint, n: usize) -> CrateBigUint {
         match n {
-            0 => BigUint::new(vec![0]),
+            0 => CrateBigUint::new(vec![0]),
             1 => first,
             2 => second,
             _ => {
@@ -86,34 +39,35 @@ mod crate_biguint_benchmarks {
         }
     }
 
+    fn fac(n: usize) -> CrateBigUint {
+        let mut result = CrateBigUint::new(vec![1]);
+        (1..n + 1).rev().for_each(|x| {
+            result *= x as u64;
+        });
+        result
+    }
+
     #[bench]
     fn bench_fib_27_crate(b: &mut Bencher) {
         b.iter(|| {
-            fib_generic(BigUint::new(vec![1]), BigUint::new(vec![1]), 27);
+            fib_generic(CrateBigUint::new(vec![1]), CrateBigUint::new(vec![1]), 27);
         });
     }
 
     #[bench]
     fn bench_fib_272_crate(b: &mut Bencher) {
         b.iter(|| {
-            fib_generic(BigUint::new(vec![1]), BigUint::new(vec![1]), 272);
+            fib_generic(CrateBigUint::new(vec![1]), CrateBigUint::new(vec![1]), 272);
         });
     }
 
     #[bench]
     fn bench_fib_2727_crate(b: &mut Bencher) {
         b.iter(|| {
-            fib_generic(BigUint::new(vec![1]), BigUint::new(vec![1]), 2_727);
+            fib_generic(CrateBigUint::new(vec![1]), CrateBigUint::new(vec![1]), 2_727);
         });
     }
 
-    fn fac(n: usize) -> BigUint {
-        let mut result = BigUint::new(vec![1]);
-        (1..n + 1).rev().for_each(|x| {
-            result *= x as u64;
-        });
-        result
-    }
 
     #[bench]
     fn bench_fac_27_crate(b: &mut Bencher) {
@@ -136,4 +90,45 @@ mod crate_biguint_benchmarks {
         });
     }
 
+    #[bench]
+    fn bench_fib_27_local(b: &mut Bencher) {
+        b.iter(|| {
+            LocalBigUint::fib(27);
+        });
+    }
+
+    #[bench]
+    fn bench_fib_272_local(b: &mut Bencher) {
+        b.iter(|| {
+            LocalBigUint::fib(272);
+        });
+    }
+
+    #[bench]
+    fn bench_fib_2727_local(b: &mut Bencher) {
+        b.iter(|| {
+            LocalBigUint::fib(2_727);
+        });
+    }
+
+    #[bench]
+    fn bench_fac_27_local(b: &mut Bencher) {
+        b.iter(|| {
+            LocalBigUint::fac(27);
+        });
+    }
+
+    #[bench]
+    fn bench_fac_272_local(b: &mut Bencher) {
+        b.iter(|| {
+            LocalBigUint::fac(272);
+        });
+    }
+
+    #[bench]
+    fn bench_fac_2727_local(b: &mut Bencher) {
+        b.iter(|| {
+            LocalBigUint::fac(2727);
+        });
+    }
 }


### PR DESCRIPTION
Benchmarks now execute pair-wise between the local BigUint and the Crates.io BigUint.

This is much easier to compare differences for the same functionality.

Previously all of crate would bench, then all of local would bench.